### PR TITLE
Wise pluggin exposure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ opensearch
 opensearch-backup
 arkime-logs
 arkime-raw
+arkime/wiseini
 kubernetes
 malcolm-iso
 hedgehog-iso

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /arkime/etc/GeoLite2-*
 /arkime/etc/oui.txt*
 /arkime/etc/wise.ini
+/arkime/wiseini
 /arkime/etc/ipv4-address-space.csv*
 /README.css
 
@@ -32,6 +33,7 @@ config.*/
 .direnv
 .vagrant
 .fuse_*
+.venv
 malcolm_*images.tar.gz
 malcolm_*images.tar.xz
 malcolm_netbox_backup_*.gz

--- a/arkime/scripts/docker_entrypoint.sh
+++ b/arkime/scripts/docker_entrypoint.sh
@@ -203,8 +203,16 @@ if [[ ! -f "${ARKIME_CONFIG_FILE}" ]] && [[ -r "${ARKIME_DIR}"/etc/config.orig.i
     [[ -n ${PGID} ]] && chown -f :${PGID} "${ARKIME_CONFIG_FILE}" || true
 fi 
 
+
+# An example wise.ini file is baked into the container image by the Dockerfile as $ARKIME_DIR/etc/wise.ini.example
+# After the container is booted we copy wise.ini.example from $ARMIKE_DIR/etc/ to $ARKIME_DIR/wiseini/
+# if $ARKIME_DIR/wiseini/wise.ini does not already exist.
+# $ARKIME_DIR/wiseini/wise.ini will either be a R/W mounted file, when run under Docker Compose or
+# $ARKIME_DIR/wiseini/ will be a persistent volume when run under Kubernetes.
+# This allows changes to persist when the wise application edits its own ini file at runtime.
 if [[ ! -f "${ARKIME_WISE_CONFIG_FILE}" ]] && [[ -r "${ARKIME_WISE_EXAMPLE_FILE}" ]]; then
     cp "${ARKIME_WISE_EXAMPLE_FILE}" "${ARKIME_WISE_CONFIG_FILE}"
+    chown -fR "$PUSER":"$PUSER" "${ARKIME_DIR}"/wiseini
 fi
 
 if [[ ${ARKIME_EXPOSE_WISE_GUI}  == "true" ]]; then

--- a/arkime/scripts/wise_service.sh
+++ b/arkime/scripts/wise_service.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Battelle Energy Alliance, LLC.  All rights reserved.
 
 while true; do
-  if [[ (("$WISE" == "on") || ("$ARKIME_LIVE_CAPTURE" == "true")) && (-f /var/run/arkime/runwise) && (-f $ARKIME_DIR/etc/wise.ini) ]]; then
+  if [[ (("$WISE" == "on") || ("$ARKIME_LIVE_CAPTURE" == "true")) && (-f /var/run/arkime/runwise) && (-f $ARKIME_DIR/wiseini/wise.ini) ]]; then
     echo "Launch wise..."
     rm -f $ARKIME_DIR/logs/wise*
     pushd $ARKIME_DIR/wiseService >/dev/null 2>&1

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -432,6 +432,11 @@ services:
     - type: bind
       bind:
         create_host_path: false
+      source: ./arkime/etc/wise.ini
+      target: /opt/arkime/wiseini/wise.ini
+    - type: bind
+      bind:
+        create_host_path: false
       source: ./arkime/etc/config.ini
       target: /opt/arkime/etc/config.orig.ini
       read_only: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -372,7 +372,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/arkime.Dockerfile
-    image: ghcr.io/idaholab/malcolm/arkime:25.04.0
+    image: ghcr.io/scott-jeffery/malcolm/arkime:wise_pluggin_exposure
     profiles: ["malcolm", "hedgehog"]
     logging:
       driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,7 +330,7 @@ services:
       retries: 3
       start_period: 60s
   arkime:
-    image: ghcr.io/idaholab/malcolm/arkime:25.04.0
+    image: ghcr.io/scott-jeffery/malcolm/arkime:modify_arkime_container
     profiles: ["malcolm", "hedgehog"]
     logging:
       driver: local
@@ -466,7 +466,6 @@ services:
         create_host_path: false
       source: ./arkime/etc/wise.ini
       target: /opt/arkime/wiseini/wise.ini
-      read_only: true
     healthcheck:
       test: ["CMD", "/usr/local/bin/container_health.sh"]
       interval: 90s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,7 +330,7 @@ services:
       retries: 3
       start_period: 60s
   arkime:
-    image: ghcr.io/scott-jeffery/malcolm/arkime:modify_arkime_container
+    image: ghcr.io/scott-jeffery/malcolm/arkime:wise_pluggin_exposure
     profiles: ["malcolm", "hedgehog"]
     logging:
       driver: local

--- a/kubernetes/07-arkime.yml
+++ b/kubernetes/07-arkime.yml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: arkime-container
-        image: ghcr.io/scott-jeffery/malcolm/arkime:modify_arkime_container
+        image: ghcr.io/scott-jeffery/malcolm/arkime:wise_pluggin_exposure
         imagePullPolicy: Always
         stdin: false
         tty: true

--- a/kubernetes/07-arkime.yml
+++ b/kubernetes/07-arkime.yml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: arkime-container
-        image: ghcr.io/idaholab/malcolm/arkime:25.04.0
+        image: ghcr.io/scott-jeffery/malcolm/arkime:modify_arkime_container
         imagePullPolicy: Always
         stdin: false
         tty: true
@@ -83,9 +83,9 @@ spec:
             name: arkime-rules-volume
           - mountPath: "/data/pcap"
             name: arkime-pcap-volume
-          - mountPath: /opt/arkime/etc/wise.ini
-            name: wise-file-volume
-            subPath: wise.ini  
+          - mountPath: "/opt/arkime/wiseini"
+            name: arkime-config-volume
+            subPath: "arkime/wiseini"  
       initContainers:
       - name: arkime-dirinit-container
         image: ghcr.io/idaholab/malcolm/dirinit:25.04.0
@@ -104,10 +104,12 @@ spec:
               name: process-env
         env:
           - name: PUSER_MKDIR
-            value: "/data/pcap:processed"
+            value: "/data/config:arkime/wiseini;/data/pcap:processed"
         volumeMounts:
           - name: arkime-pcap-volume
             mountPath: "/data/pcap"
+          - name: arkime-config-volume
+            mountPath: "/data/config"
       volumes:
         - name: arkime-var-local-catrust-volume
           configMap:
@@ -124,3 +126,6 @@ spec:
         - name: arkime-pcap-volume
           persistentVolumeClaim:
             claimName: pcap-claim
+        - name: arkime-config-volume
+          persistentVolumeClaim:
+            claimName: config-claim


### PR DESCRIPTION
* Add dynamically created wiseini persistence directory to dockerignore
* Add dynamically created wiseini persistence directory to .gitignore
* Add typical python virtualenv directory name to gitignore for those who use .venv or can't "break system packages"
* Tweak docker_entrypoint.sh to ensure wiseini directory owned by arkime user
* Tweak wise_serivce.sh to check for config file in wiseini directory
* Tweak docker-compose-dev to use development ghcr repo for now
* Add docker-compose-dev bind for wise.ini persistence in source tree
* Tweak docker-compose to use development ghcr repo for now
* Remove "read_only" from docker-compose wiseini bind
* Setup 07-arkime.yml to use development ghcr repo for now
* Add 07-arkime.yml wiseini persistent volume mount
* Add 07-arkime.yml wiseini init container mount and PUSER mkdir in that path
* Add 07-arkmine.yml arkime-config-claim using existing config-claim
